### PR TITLE
Fixes usage of deprecated array/string access syntax.

### DIFF
--- a/lib/TemplateRender.php
+++ b/lib/TemplateRender.php
@@ -200,7 +200,7 @@ class TemplateRender extends PageRender {
 					$next_number = $vals;
 
 					foreach ($mod as $calc) {
-						$operand = $calc{0};
+						$operand = $calc[0];
 						$operator = substr ($calc,1);
 
 						switch ($operand) {

--- a/lib/export_functions.php
+++ b/lib/export_functions.php
@@ -223,7 +223,7 @@ abstract class Export {
 	 */
 	protected function isSafeAscii($str) {
 		for ($i=0;$i<strlen($str);$i++)
-			if (ord($str{$i}) < 32 || ord($str{$i}) > 127)
+			if (ord($str[$i]) < 32 || ord($str[$i]) > 127)
 				return false;
 
 		return true;

--- a/lib/functions.php
+++ b/lib/functions.php
@@ -1638,7 +1638,7 @@ function get_icon($server_id,$dn,$object_classes=array()) {
 
 	# Return icon filename based upon objectClass value
 	if (in_array('sambaaccount',$object_classes) &&
-		'$' == $rdn{ strlen($rdn) - 1 })
+		'$' == $rdn[ strlen($rdn) - 1 ])
 		return 'nt_machine.png';
 
 	if (in_array('sambaaccount',$object_classes))


### PR DESCRIPTION
Other deprecations have been checked for and have, with the exception of four instances of
array_key_exist(), been found to not be present or not pose a problem.

### Deprecations in php 7.4.0
- [x] https://wiki.php.net/rfc/deprecate_curly_braces_array_access
    - used script provided in rfc for conversion
    - 4 usages over 3 files have been changed
- [x] https://wiki.php.net/rfc/deprecations_php_7_4#magic_quotes_legacy
    - [x] The 'real' Type
        - not found
    - [x] Magic quotes legacy
        - [x] (emuhash_function.php:62) once used only used when version is <6
        - [x] (common.php:299) prefixed with @
    - [x] array_key_exists() with objects
        - [x] (config_default.php:710) prior is_array check
        - [ ] (ds.php:64) ¯\\_( ツ )_/¯
        - [ ] (ds.php:77) ¯\\_( ツ )_/¯
        - [ ] (ds_ldap.php:2323) is $group an array?
        - [x] (ds_ldap.php:2326) fine see line 2324
        - [ ] (ds_ldap.php:2332) is $group an array?
        - [x] (ds_ldap.php:2335) fine see line 2333
        - [ ] (export_functions.php:296) ¯\\_( ツ )_/¯
        - [x] (hooks.php:58) every write to $_SESSION\[APPCONFIG]->hooks is an array
        - [x] (hooks.php:133) every write to $_SESSION\[APPCONFIG]->hooks is an array
        - [x] (hooks.php:159) every write to $_SESSION\[APPCONFIG]->hooks is an array
        - [x] (hooks.php:182) every write to $_SESSION\[APPCONFIG]->hooks is an array
        - [x] (session_functions.php:89) $_SESSION should be an array
        - [x] (session_functions.php:100) explicit is_array() check
    - [x] FILTER_SANITIZE_MAGIC_QUOTES
        - not found
    - [x] Reflection export() methods
        - not found
        - there are export functions but non are relevant here
    - [x] mb_strrpos() with encoding as 3rd argument
        - not found
    - [x] implode() parameter order mix
        - all 34 usages have the correct order
    - [x] Unbinding $this from non-static closures
        - not found
    - [x] hebrevc() function
        - not found
    - [x] convert_cyr_string()
        - not found
    - [x] money_format()
        - not found
    - [x] ezmlm_hash()
        - not found
    - [x] restore_include_path() function
        - not found
    - [x] allow_url_include
        - not found
- [x] https://wiki.php.net/rfc/ternary_associativity
    - found only one instance of nested ternary, which is explicit using parenthesis